### PR TITLE
feat: 포인트 조회 기능 구현

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserCommand.java
@@ -1,0 +1,39 @@
+package com.loopers.domain.user;
+
+public class UserCommand {
+    public record SignUp(
+            String loginId,
+            String name,
+            String gender,
+            String email,
+            String dob
+    ) {
+        public UserEntity toEntity() {
+            return UserEntity.create(
+                    loginId,
+                    name,
+                    gender,
+                    email,
+                    dob
+            );
+        }
+    }
+
+    public record UserInfo(
+            String loginId,
+            String name,
+            String gender,
+            String email,
+            String dob
+    ) {
+        public static UserInfo fromEntity(UserEntity userEntity) {
+            return new UserInfo(
+                    userEntity.getLoginId(),
+                    userEntity.getName(),
+                    userEntity.getGender(),
+                    userEntity.getEmail(),
+                    userEntity.getDob()
+            );
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserCommand.java
@@ -6,7 +6,8 @@ public class UserCommand {
             String name,
             String gender,
             String email,
-            String dob
+            String dob,
+            long point
     ) {
         public UserEntity toEntity() {
             return UserEntity.create(
@@ -14,7 +15,8 @@ public class UserCommand {
                     name,
                     gender,
                     email,
-                    dob
+                    dob,
+                    point
             );
         }
     }
@@ -24,7 +26,8 @@ public class UserCommand {
             String name,
             String gender,
             String email,
-            String dob
+            String dob,
+            Long point
     ) {
         public static UserInfo fromEntity(UserEntity userEntity) {
             return new UserInfo(
@@ -32,7 +35,8 @@ public class UserCommand {
                     userEntity.getName(),
                     userEntity.getGender(),
                     userEntity.getEmail(),
-                    userEntity.getDob()
+                    userEntity.getDob(),
+                    userEntity.getPoint()
             );
         }
     }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserEntity.java
@@ -1,0 +1,10 @@
+package com.loopers.domain.user;
+
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "users")
+public class UserEntity extends BaseEntity {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserEntity.java
@@ -1,10 +1,63 @@
 package com.loopers.domain.user;
 
 import com.loopers.domain.BaseEntity;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserEntity extends BaseEntity {
+    final static String PATTERN_USER_ID = "^(?=.*[a-zA-Z])(?=.*[0-9])[a-zA-Z0-9]{1,10}$";
+    final static String PATTERN_EMAIL = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$";
+    final static String PATTERN_DOB = "^\\d{4}-\\d{2}-\\d{2}$";
+
+    private String loginId;
+    private String name;
+    private String gender;
+    private String email;
+    private String dob;
+
+    // constructor
+    private UserEntity(String loginId, String name, String gender, String email, String dob) {
+        this.loginId = loginId;
+        this.name = name;
+        this.gender = gender;
+        this.email = email;
+        this.dob = dob;
+    }
+
+    // static factory method
+    public static UserEntity create(
+            String loginId,
+            String name,
+            String gender,
+            String email,
+            String dob
+    ) {
+        if (loginId == null || !loginId.matches(PATTERN_USER_ID)) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "ID는 영문 및 숫자 10자 이내로 입력해주세요.");
+        }
+
+        email = email.trim();
+        if (!email.matches(PATTERN_EMAIL) || email.contains(" ")) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "이메일 형식이 올바르지 않습니다.");
+        }
+
+        if (!dob.matches(PATTERN_DOB)) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "생년월일 형식이 올바르지 않습니다.");
+        }
+
+        if (gender == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "성별을 입력해주세요.");
+        }
+
+        return new UserEntity(loginId, name, gender, email, dob);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserEntity.java
@@ -23,14 +23,16 @@ public class UserEntity extends BaseEntity {
     private String gender;
     private String email;
     private String dob;
+    private Long point;
 
     // constructor
-    private UserEntity(String loginId, String name, String gender, String email, String dob) {
+    private UserEntity(String loginId, String name, String gender, String email, String dob, long point) {
         this.loginId = loginId;
         this.name = name;
         this.gender = gender;
         this.email = email;
         this.dob = dob;
+        this.point = point;
     }
 
     // static factory method
@@ -39,7 +41,8 @@ public class UserEntity extends BaseEntity {
             String name,
             String gender,
             String email,
-            String dob
+            String dob,
+            long point
     ) {
         if (loginId == null || !loginId.matches(PATTERN_USER_ID)) {
             throw new CoreException(ErrorType.BAD_REQUEST, "ID는 영문 및 숫자 10자 이내로 입력해주세요.");
@@ -58,6 +61,6 @@ public class UserEntity extends BaseEntity {
             throw new CoreException(ErrorType.BAD_REQUEST, "성별을 입력해주세요.");
         }
 
-        return new UserEntity(loginId, name, gender, email, dob);
+        return new UserEntity(loginId, name, gender, email, dob, point);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserRepository.java
@@ -4,4 +4,6 @@ public interface UserRepository {
     UserEntity save(UserEntity userEntity);
 
     UserEntity findByLoginId(String loginId);
+
+    Long findPointByLoginId(String loginId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserRepository.java
@@ -1,0 +1,4 @@
+package com.loopers.domain.user;
+
+public interface UserRepository {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserRepository.java
@@ -1,4 +1,7 @@
 package com.loopers.domain.user;
 
 public interface UserRepository {
+    UserEntity save(UserEntity userEntity);
+
+    UserEntity findByLoginId(String loginId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
@@ -26,4 +26,13 @@ public class UserService {
         }
         return UserCommand.UserInfo.fromEntity(userEntity);
     }
+
+    public Long getPoint(String loginId) {
+        UserEntity userEntity = userRepository.findByLoginId(loginId);
+        if(userEntity == null) {
+            return null;
+        }
+
+        return userRepository.findPointByLoginId(loginId);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
@@ -1,0 +1,9 @@
+package com.loopers.domain.user;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class UserService {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
@@ -18,4 +18,12 @@ public class UserService {
         UserEntity userEntity = userRepository.save(signUpCommand.toEntity());
         return UserCommand.UserInfo.fromEntity(userEntity);
     }
+
+    public UserCommand.UserInfo getMyInfo(String loginId) {
+        UserEntity userEntity = userRepository.findByLoginId(loginId);
+        if (userEntity == null) {
+            return null;
+        }
+        return UserCommand.UserInfo.fromEntity(userEntity);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
@@ -1,9 +1,21 @@
 package com.loopers.domain.user;
 
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @RequiredArgsConstructor
 @Component
 public class UserService {
+    private final UserRepository userRepository;
+
+    public UserCommand.UserInfo signUp(UserCommand.SignUp signUpCommand) {
+        if(userRepository.findByLoginId(signUpCommand.loginId()) != null) {
+            throw new CoreException(ErrorType.CONFLICT, "이미 가입된 ID 입니다.");
+        }
+
+        UserEntity userEntity = userRepository.save(signUpCommand.toEntity());
+        return UserCommand.UserInfo.fromEntity(userEntity);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserJpaRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.infrastructure.user;
+
+import com.loopers.domain.user.UserEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserJpaRepository.java
@@ -3,5 +3,8 @@ package com.loopers.infrastructure.user;
 import com.loopers.domain.user.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
+    Optional<UserEntity> findByLoginId(String loginId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserRepositoryImpl.java
@@ -2,8 +2,6 @@ package com.loopers.infrastructure.user;
 
 import com.loopers.domain.user.UserEntity;
 import com.loopers.domain.user.UserRepository;
-import com.loopers.support.error.CoreException;
-import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserRepositoryImpl.java
@@ -1,10 +1,24 @@
 package com.loopers.infrastructure.user;
 
+import com.loopers.domain.user.UserEntity;
 import com.loopers.domain.user.UserRepository;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @RequiredArgsConstructor
 @Component
 public class UserRepositoryImpl implements UserRepository {
+    private final UserJpaRepository userJpaRepository;
+
+    @Override
+    public UserEntity save(UserEntity userEntity) {
+        return userJpaRepository.save(userEntity);
+    }
+
+    @Override
+    public UserEntity findByLoginId(String loginId) {
+        return userJpaRepository.findByLoginId(loginId).orElse(null);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserRepositoryImpl.java
@@ -1,0 +1,10 @@
+package com.loopers.infrastructure.user;
+
+import com.loopers.domain.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class UserRepositoryImpl implements UserRepository {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserRepositoryImpl.java
@@ -19,4 +19,14 @@ public class UserRepositoryImpl implements UserRepository {
     public UserEntity findByLoginId(String loginId) {
         return userJpaRepository.findByLoginId(loginId).orElse(null);
     }
+
+    @Override
+    public Long findPointByLoginId(String loginId) {
+        UserEntity userEntity = userJpaRepository.findByLoginId(loginId).orElse(null);
+
+        if(userEntity == null) {
+            return null;
+        }
+        return userEntity.getPoint();
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ApiControllerAdvice.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ApiControllerAdvice.java
@@ -8,6 +8,7 @@ import com.loopers.support.error.ErrorType;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -73,7 +74,7 @@ public class ApiControllerAdvice {
 
         } else if (rootCause instanceof MismatchedInputException mismatchedInput) {
             String fieldPath = mismatchedInput.getPath().stream()
-                .map(ref -> ref.getFieldName() != null ? ref.getFieldName() : "?")
+                        .map(ref -> ref.getFieldName() != null ? ref.getFieldName() : "?")
                 .collect(Collectors.joining("."));
             errorMessage = String.format("필수 필드 '%s'이(가) 누락되었습니다.", fieldPath);
 
@@ -111,6 +112,15 @@ public class ApiControllerAdvice {
     public ResponseEntity<ApiResponse<?>> handle(Throwable e) {
         log.error("Exception : {}", e.getMessage(), e);
         return failureResponse(ErrorType.INTERNAL_ERROR, null);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ApiResponse<?>> handleValidationException(MethodArgumentNotValidException e) {
+        String message = e.getBindingResult().getFieldErrors().stream()
+                .map(error -> String.format("필드 '%s': %s", error.getField(), error.getDefaultMessage()))
+                .collect(Collectors.joining("; "));
+
+        return failureResponse(ErrorType.BAD_REQUEST, message);
     }
 
     private String extractMissingParameter(String message) {

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ApiControllerAdvice.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ApiControllerAdvice.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -120,6 +121,19 @@ public class ApiControllerAdvice {
                 .map(error -> String.format("필드 '%s': %s", error.getField(), error.getDefaultMessage()))
                 .collect(Collectors.joining("; "));
 
+        return failureResponse(ErrorType.BAD_REQUEST, message);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ApiResponse<?>> handle(MissingRequestHeaderException e) {
+        String headerName = e.getHeaderName();
+
+        if("X-USER-ID".equals(headerName)) {
+            String message = String.format("필수 요청 헤더 '%s'가 누락되었습니다.", headerName);
+            return failureResponse(ErrorType.BAD_REQUEST, message);
+        }
+
+        String message = String.format("필수 요청 헤더 '%s'가 누락되었습니다.", headerName);
         return failureResponse(ErrorType.BAD_REQUEST, message);
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiController.java
@@ -1,5 +1,9 @@
 package com.loopers.interfaces.api.point;
 
+import com.loopers.domain.user.UserService;
+import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -8,4 +12,23 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/v1/points")
 public class PointV1ApiController implements PointV1ApiSpec {
 
+    private final UserService pointService;
+
+    @GetMapping
+    public ApiResponse<PointV1ApiDto.GetPointResponse> getPoint(
+            @RequestHeader("X-USER-ID") String loginId,
+            PointV1ApiDto.GetPointRequest getPointRequest
+    ) {
+        if (loginId == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "로그인 ID가 누락되었습니다.");
+        }
+
+        Long point = pointService.getPoint(loginId);
+        if (point == null) {
+            return ApiResponse.success(new PointV1ApiDto.GetPointResponse(0L));
+        }
+
+        PointV1ApiDto.GetPointResponse response = PointV1ApiDto.GetPointResponse.from(point);
+        return ApiResponse.success(response);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiController.java
@@ -1,0 +1,11 @@
+package com.loopers.interfaces.api.point;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/points")
+public class PointV1ApiController implements PointV1ApiSpec {
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiDto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiDto.java
@@ -1,5 +1,19 @@
 package com.loopers.interfaces.api.point;
 
 public class PointV1ApiDto {
+    public record GetPointRequest (
+            String userId
+    ) {
+    }
+
+    public record GetPointResponse (
+            Long point
+    ) {
+        public static GetPointResponse from(Long point) {
+            return new GetPointResponse(
+                    point
+            );
+        }
+    }
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiDto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiDto.java
@@ -1,0 +1,5 @@
+package com.loopers.interfaces.api.point;
+
+public class PointV1ApiDto {
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiSpec.java
@@ -1,0 +1,7 @@
+package com.loopers.interfaces.api.point;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Point V1 API", description = "사용자 API V1 입니다.")
+public interface PointV1ApiSpec {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiSpec.java
@@ -1,7 +1,9 @@
 package com.loopers.interfaces.api.point;
 
+import com.loopers.interfaces.api.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name = "Point V1 API", description = "사용자 API V1 입니다.")
 public interface PointV1ApiSpec {
+    ApiResponse<PointV1ApiDto.GetPointResponse> getPoint(String loginId, PointV1ApiDto.GetPointRequest getPointRequest);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiController.java
@@ -1,11 +1,31 @@
 package com.loopers.interfaces.api.user;
 
+import com.loopers.domain.user.UserCommand;
+import com.loopers.domain.user.UserService;
+import com.loopers.interfaces.api.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/v1/users")
-public class UserV1ApiController {
+public class UserV1ApiController implements UserV1ApiSpec {
+
+    private final UserService userService;
+
+    @PostMapping
+    @Override
+    public ApiResponse<UserV1ApiDto.SignUpResponse> signUp(
+            @RequestBody @Valid UserV1ApiDto.SignUpRequest signUpRequest
+    ) {
+        UserCommand.SignUp userCommand = signUpRequest.toCommand();
+        UserCommand.UserInfo userInfo = userService.signUp(userCommand);
+
+        UserV1ApiDto.SignUpResponse response = UserV1ApiDto.SignUpResponse.from(userInfo);
+        return ApiResponse.success(response);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiController.java
@@ -3,12 +3,11 @@ package com.loopers.interfaces.api.user;
 import com.loopers.domain.user.UserCommand;
 import com.loopers.domain.user.UserService;
 import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
@@ -27,5 +26,24 @@ public class UserV1ApiController implements UserV1ApiSpec {
 
         UserV1ApiDto.SignUpResponse response = UserV1ApiDto.SignUpResponse.from(userInfo);
         return ApiResponse.success(response);
+    }
+
+    @GetMapping("/me")
+    public ApiResponse<UserV1ApiDto.SignUpResponse> getMyInfo(
+            @RequestHeader("X-USER-ID") String loginId
+    ) {
+        if (loginId == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "로그인 ID가 누락되었습니다.");
+        }
+
+        UserCommand.UserInfo userInfo = userService.getMyInfo(loginId);
+
+        if (userInfo == null || userInfo.loginId() == null) {
+            throw new CoreException(ErrorType.NOT_FOUND, "존재하지 않는 사용자입니다.");
+        }
+
+        UserV1ApiDto.SignUpResponse response = UserV1ApiDto.SignUpResponse.from(userInfo);
+        return ApiResponse.success(response);
+
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiController.java
@@ -1,0 +1,11 @@
+package com.loopers.interfaces.api.user;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/users")
+public class UserV1ApiController {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiDto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiDto.java
@@ -1,0 +1,4 @@
+package com.loopers.interfaces.api.user;
+
+public class UserV1ApiDto {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiDto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiDto.java
@@ -1,4 +1,53 @@
 package com.loopers.interfaces.api.user;
 
+import com.loopers.domain.user.UserCommand;
+import jakarta.validation.constraints.NotNull;
+
 public class UserV1ApiDto {
+    // 데이터 전달 용도 -> record
+    public record SignUpRequest(
+            @NotNull String loginId,
+            @NotNull String name,
+            @NotNull GenderRequest gender,
+            @NotNull String email,
+            @NotNull String dob
+    ) {
+        enum GenderRequest {
+            M,
+            F
+        }
+
+        public UserCommand.SignUp toCommand() {
+            return new UserCommand.SignUp(
+                    loginId,
+                    name,
+                    gender.toString(),
+                    email,
+                    dob
+            );
+        }
+    }
+
+    public record SignUpResponse(
+            String loginId,
+            String name,
+            GenderResponse gender,
+            String email,
+            String dob
+    ) {
+        enum GenderResponse {
+            M,
+            F
+        }
+
+        public static SignUpResponse from(UserCommand.UserInfo userInfo) {
+            return new SignUpResponse(
+                    userInfo.loginId(),
+                    userInfo.name(),
+                    GenderResponse.valueOf(userInfo.gender()),
+                    userInfo.email(),
+                    userInfo.dob()
+            );
+        }
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiDto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiDto.java
@@ -23,7 +23,8 @@ public class UserV1ApiDto {
                     name,
                     gender.toString(),
                     email,
-                    dob
+                    dob,
+                    0L
             );
         }
     }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
@@ -1,4 +1,12 @@
 package com.loopers.interfaces.api.user;
 
-public class UserV1ApiSpec {
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "User V1 API", description = "사용자 API V1 입니다.")
+public interface UserV1ApiSpec {
+
+    @Operation(summary = "회원 가입")
+    ApiResponse<UserV1ApiDto.SignUpResponse> signUp(UserV1ApiDto.SignUpRequest signUpRequest);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
@@ -1,0 +1,4 @@
+package com.loopers.interfaces.api.user;
+
+public class UserV1ApiSpec {
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
@@ -1,0 +1,72 @@
+package com.loopers.domain.point;
+
+import com.loopers.domain.user.UserCommand;
+import com.loopers.domain.user.UserRepository;
+import com.loopers.domain.user.UserService;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@Testcontainers
+@SpringBootTest
+@Transactional
+public class PointServiceIntegrationTest {
+    /**
+     * - [x]  해당 ID 의 회원이 존재할 경우, 보유 포인트가 반환된다.
+     * - [x]  해당 ID 의 회원이 존재하지 않을 경우, null 이 반환된다.
+     */
+    @Autowired
+    private UserService pointService;
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private UserRepository pointRepository;
+
+    @DisplayName("해당 ID 의 회원이 존재할 경우, 보유 포인트가 반환된다.")
+    @Test
+    void returnsPoint_whenUserExists() {
+        // given
+        final String loginId = "test123456";
+        UserCommand.SignUp userCommand = new UserCommand.SignUp(
+                loginId,
+                "test",
+                "F",
+                "test@example.com",
+                "2025-01-01",
+                10000L
+        );
+        userService.signUp(userCommand);
+
+        // when
+        Long point = pointService.getPoint(loginId);
+
+        // then
+        assertAll(
+                () -> assertThat(point).isNotNull(),
+                () -> assertThat(point).isEqualTo(10000L)
+        );
+    }
+
+    @DisplayName("해당 ID 의 회원이 존재하지 않을 경우, null 이 반환된다.")
+    @Test
+    void returnsNull_whenUserDoesNotExist() {
+        // given
+        final String loginId = "test123456";
+
+        // when
+        Long point = pointService.getPoint(loginId);
+
+        // then
+        assertThat(point).isNull();
+    }
+
+
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
@@ -27,9 +27,6 @@ public class PointServiceIntegrationTest {
     @Autowired
     private UserService userService;
 
-    @Autowired
-    private UserRepository pointRepository;
-
     @DisplayName("해당 ID 의 회원이 존재할 경우, 보유 포인트가 반환된다.")
     @Test
     void returnsPoint_whenUserExists() {

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.loopers.domain.user;
 
+import com.loopers.support.error.CoreException;
 import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -63,7 +64,7 @@ public class UserServiceIntegrationTest {
         userService.signUp(userCommand);
 
         // when & then
-        assertThrows(RuntimeException.class, () -> {
+        assertThrows(CoreException.class, () -> {
             userService.signUp(userCommand);
         });
     }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
@@ -1,0 +1,70 @@
+package com.loopers.domain.user;
+
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@Testcontainers
+@SpringBootTest
+@Transactional
+public class UserServiceIntegrationTest {
+    /**
+     * - [x]회원 가입시 User 저장이 수행된다.
+     * - [x]이미 가입된 ID 로 회원가입 시도 시, 실패한다.
+     */
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @DisplayName("회원 가입시 User 저장이 수행된다.")
+    @Test
+    void saveUser_whenSignUp() {
+        // given
+        final String loginId = "test123456";
+        UserCommand.SignUp userCommand = new UserCommand.SignUp(
+                loginId,
+                "test",
+                "F",
+                "test@example.com",
+                "2025-01-01"
+        );
+
+        // when
+        userService.signUp(userCommand);
+
+        // then
+        UserEntity userEntity = userRepository.findByLoginId(loginId);
+        assertAll(
+                () -> assertThat(userCommand.loginId()).isEqualTo(userEntity.getLoginId())
+        );
+
+    }
+
+    @DisplayName("이미 가입된 ID 로 회원가입 시도 시, 실패한다.")
+    @Test
+    void fail_whenSignUpWithDuplicateId() {
+        // given
+        UserCommand.SignUp userCommand = new UserCommand.SignUp(
+                "test123456",
+                "test",
+                "F",
+                "test@example.com",
+                "2025-01-01"
+        );
+        userService.signUp(userCommand);
+
+        // when & then
+        assertThrows(RuntimeException.class, () -> {
+            userService.signUp(userCommand);
+        });
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
@@ -2,6 +2,7 @@ package com.loopers.domain.user;
 
 import com.loopers.support.error.CoreException;
 import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,6 +20,9 @@ public class UserServiceIntegrationTest {
     /**
      * - [x]회원 가입시 User 저장이 수행된다.
      * - [x]이미 가입된 ID 로 회원가입 시도 시, 실패한다.
+     *
+     * - [x]해당 ID 의 회원이 존재할 경우, 회원 정보가 반환된다.
+     * - [x]해당 ID 의 회원이 존재하지 않을 경우, null 이 반환된다.
      */
     @Autowired
     private UserService userService;
@@ -67,5 +71,45 @@ public class UserServiceIntegrationTest {
         assertThrows(CoreException.class, () -> {
             userService.signUp(userCommand);
         });
+    }
+
+    @DisplayName("해당 ID 의 회원이 존재할 경우, 회원 정보가 반환된다.")
+    @Test
+    void returnsUserInformation_whenUserExists() {
+        // given
+        final String loginId = "test123456";
+        UserCommand.SignUp userCommand = new UserCommand.SignUp(
+                loginId,
+                "test",
+                "F",
+                "test@example.com",
+                "2025-01-01"
+        );
+        userService.signUp(userCommand);
+
+        // when
+        UserCommand.UserInfo userInfo = userService.getMyInfo(loginId);
+
+        // then
+        assertAll(
+                () -> assertThat(userInfo).isNotNull(),
+                () -> {
+                    Assertions.assertNotNull(userInfo);
+                    assertThat(userInfo.loginId()).isEqualTo(loginId);
+                }
+        );
+    }
+
+    @DisplayName("해당 ID 의 회원이 존재하지 않을 경우, null 이 반환된다.")
+    @Test
+    void returnsNull_whenUserDoesNotExist() {
+        // given
+        final String loginId = "test123456";
+
+        // when
+        UserCommand.UserInfo userInfo = userService.getMyInfo(loginId);
+
+        // then
+        assertThat(userInfo).isNull();
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
@@ -40,7 +40,8 @@ public class UserServiceIntegrationTest {
                 "test",
                 "F",
                 "test@example.com",
-                "2025-01-01"
+                "2025-01-01",
+                0L
         );
 
         // when
@@ -63,7 +64,8 @@ public class UserServiceIntegrationTest {
                 "test",
                 "F",
                 "test@example.com",
-                "2025-01-01"
+                "2025-01-01",
+                0L
         );
         userService.signUp(userCommand);
 
@@ -83,7 +85,8 @@ public class UserServiceIntegrationTest {
                 "test",
                 "F",
                 "test@example.com",
-                "2025-01-01"
+                "2025-01-01",
+                0L
         );
         userService.signUp(userCommand);
 

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserTest.java
@@ -37,7 +37,7 @@ public class UserTest {
 
         // when
         final CoreException exception = assertThrows(CoreException.class, () -> {
-            UserEntity userEntity = UserEntity.create(loginId, name, gender, email, dob);
+            UserEntity userEntity = UserEntity.create(loginId, name, gender, email, dob, 0L);
         });
 
         // then
@@ -78,7 +78,7 @@ public class UserTest {
 
         // when
         final CoreException exception = assertThrows(CoreException.class, () -> {
-            UserEntity userEntity = UserEntity.create(loginId, name, gender, email, dob);
+            UserEntity userEntity = UserEntity.create(loginId, name, gender, email, dob, 0L);
         });
 
         // then
@@ -107,7 +107,7 @@ public class UserTest {
 
         // when
         final CoreException exception = assertThrows(CoreException.class, () -> {
-            UserEntity userEntity = UserEntity.create(loginId, name, gender, email, dob);
+            UserEntity userEntity = UserEntity.create(loginId, name, gender, email, dob, 0L);
         });
 
         // then

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserTest.java
@@ -1,0 +1,117 @@
+package com.loopers.domain.user;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class UserTest {
+    /**
+     * - [x]ID 가 `영문 및 숫자 10자 이내` 형식에 맞지 않으면, User 객체 생성에 실패한다.(UserModel)
+     * - [x]이메일이 `xx@yy.zz` 형식에 맞지 않으면, User 객체 생성에 실패한다.(UserModel)
+     * - [x]생년월일이 `yyyy-MM-dd` 형식에 맞지 않으면, User 객체 생성에 실패한다.(UserModel)
+     */
+    @DisplayName("ID 가 `영문 및 숫자 10자 이내` 형식에 맞지 않으면, User 객체 생성에 실패한다.")
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "test",
+            "testTentex",
+            "test1234567890",
+            "test1234567",
+            "1234567890",
+            "test____",
+            "",
+            "1",
+            "A"
+    })
+    void fail_whenIdFormatIsInvalid(String loginId) {
+        // given
+        final String name = "test";
+        final String gender = "F";
+        final String email = "test@example.com";
+        final String dob = "2025-01-01";
+
+        // when
+        final CoreException exception = assertThrows(CoreException.class, () -> {
+            UserEntity userEntity = UserEntity.create(loginId, name, gender, email, dob);
+        });
+
+        // then
+        assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+    }
+
+    @DisplayName("이메일이 `xx@yy.zz` 형식에 맞지 않으면, User 객체 생성에 실패한다.")
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "test",
+            "test.example.com",
+            "test.example",
+
+            "@example.com",
+            "@com",
+
+            "test@",
+            "test@.",
+            "test@..",
+
+            "test@com",
+            "test@com.",
+            "test@.com",
+
+            "test @example.com",
+            "test@ example.com",
+
+            "test@@example.com",
+
+            ""
+    })
+    void fail_whenEmailFormatIsInvalid(String email) {
+        // given
+        final String loginId = "test123456";
+        final String gender = "F";
+        final String name = "test";
+        final String dob = "2025-01-01";
+
+        // when
+        final CoreException exception = assertThrows(CoreException.class, () -> {
+            UserEntity userEntity = UserEntity.create(loginId, name, gender, email, dob);
+        });
+
+        // then
+        assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+    }
+
+    @DisplayName("생년월일이 `yyyy-MM-dd` 형식에 맞지 않으면, User 객체 생성에 실패한다.")
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "19900101",
+            "1990/01/01",
+            "90-01-01",
+            "1990-1-1",
+            "abcd-ef-gh",
+            "1990-01",
+            "1990",
+            "01-01-1990",
+            ""
+    })
+    void fail_whenDobFormatIsInvalid(String dob) {
+        // given
+        final String loginId = "test123456";
+        final String gender = "F";
+        final String name = "test";
+        final String email = "test@example.com";
+
+        // when
+        final CoreException exception = assertThrows(CoreException.class, () -> {
+            UserEntity userEntity = UserEntity.create(loginId, name, gender, email, dob);
+        });
+
+        // then
+        assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+    }
+
+}

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/point/PointV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/point/PointV1ApiE2ETest.java
@@ -1,11 +1,73 @@
 package com.loopers.interfaces.api.point;
 
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
 import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Testcontainers
 @AutoConfigureMockMvc
 public class PointV1ApiE2ETest {
+    /**
+     * - [x]포인트 조회에 성공할 경우, 보유 포인트를 응답으로 반환한다.
+     * - [x]`X-USER-ID` 헤더가 없을 경우, `400 Bad Request` 응답을 반환한다.
+     */
+
+    @DisplayName("POST /api/v1/points")
+    @Nested
+    class GetPoint {
+        @Autowired
+        private MockMvc mockMvc;
+
+        private static final String ENDPOINT = "/api/v1/points";
+
+        @DisplayName("포인트 조회에 성공할 경우, 보유 포인트를 응답으로 반환한다.")
+        @Transactional
+        @Test
+        void returnsPoint_whenGetPointSuccessful() throws Exception {
+            // given
+            final String loginId = "test123456";
+            String json = String.format("""
+                {
+                    "loginId": "%s",
+                    "name": "박이름",
+                    "gender": "F",
+                    "email": "test@example.com",
+                    "dob": "2025-01-01"
+                }
+                """, loginId);
+
+            mockMvc.perform(post("/api/v1/users")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(json))
+                    .andExpect(status().isOk());
+
+            // when&then
+            mockMvc.perform(get(ENDPOINT)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .header("X-USER-ID", loginId))
+                    .andExpect(status().isOk());
+        }
+
+        @DisplayName("`X-USER-ID` 헤더가 없을 경우, `400 Bad Request` 응답을 반환한다.")
+        @Transactional
+        @Test
+        void returnsBadRequest_whenUserIdIsMissing() throws Exception {
+            // when&then
+            mockMvc.perform(get(ENDPOINT)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isBadRequest());
+        }
+    }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/point/PointV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/point/PointV1ApiE2ETest.java
@@ -1,0 +1,11 @@
+package com.loopers.interfaces.api.point;
+
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Testcontainers
+@AutoConfigureMockMvc
+public class PointV1ApiE2ETest {
+}

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/user/UserV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/user/UserV1ApiE2ETest.java
@@ -1,0 +1,112 @@
+package com.loopers.interfaces.api.user;
+
+import com.loopers.interfaces.api.ApiResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.*;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+// 임의의 포트를 사용하여 테스트 실행
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Testcontainers
+@AutoConfigureMockMvc
+public class UserV1ApiE2ETest {
+    /**
+     * - [x]회원 가입이 성공할 경우, 생성된 유저 정보를 응답으로 반환한다.
+     * - [x]회원 가입 시에 성별이 없을 경우, `400 Bad Request` 응답을 반환한다.
+     */
+
+    @DisplayName("POST /api/v1/users")
+    @Nested
+    class signUp {
+
+        @Autowired
+        private MockMvc mockMvc;
+
+        private static final String ENDPOINT = "/api/v1/users";
+
+        @DisplayName("회원 가입이 성공할 경우, 생성된 유저 정보를 응답으로 반환한다.")
+        @Test
+        void returnsUserInformation_whenSignUpSuccessful() throws Exception {
+            // given
+            String json = """
+                {
+                    "loginId": "test123456",
+                    "name": "박이름",
+                    "gender": "F",
+                    "email": "test@example.com",
+                    "dob": "2025-01-01"
+                }
+                """;
+
+            // given
+
+            // when&then
+            mockMvc.perform(post(ENDPOINT)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(json))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.meta.result").value("SUCCESS"))
+                    .andExpect(jsonPath("$.data.loginId").value("test123456"))
+                    .andExpect(jsonPath("$.data.name").value("박이름"))
+                    .andExpect(jsonPath("$.data.gender").value("F"))
+                    .andExpect(jsonPath("$.data.email").value("test@example.com"))
+                    .andExpect(jsonPath("$.data.dob").value("2025-01-01"));
+        }
+
+        @DisplayName("회원 가입 시에 성별이 없을 경우, `400 Bad Request` 응답을 반환한다.")
+        @ParameterizedTest
+        @ValueSource(strings = {
+                """
+                {
+                    "loginId": "test123456",
+                    "name": "박이름",
+                    "email": "test@example.com",
+                    "dob": "2025-01-01"
+                }
+                """,
+                """
+                {
+                    "loginId": "test123456",
+                    "name": "박이름",
+                    "gender": null,
+                    "email": "test@example.com",
+                    "dob": "2025-01-01"
+                }
+                """,
+                """
+                {
+                    "loginId": "test123456",
+                    "name": "박이름",
+                    "gender": "",
+                    "email": "test@example.com",
+                    "dob": "2025-01-01"
+                }
+                """
+        })
+        void returnsBadRequest_whenGenderIsMissing(String json) throws Exception {
+            /**
+             * not provided : 의도적 누락
+             * missing : 필수값 누락
+             */
+            // given
+
+            // when&then
+            mockMvc.perform(post(ENDPOINT)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(json))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.meta.result").value("FAIL"))
+                    .andExpect(jsonPath("$.data").doesNotExist());
+        }
+    }
+}


### PR DESCRIPTION
## 📌 Summary
- 포인트 조회 기능 구현

## 💬 Review Points
### (2) 고민했던 설계 포인트나 로직
"X-USER-ID" 헤더가 없는 경우 Bad Request로 처리하기 위해 전역 에러 핸들러에서 MissingRequestHeaderException을 분기 처리하는 방식을 사용했는데, 컨트롤러에서 직접 검증하는 방식에 비해 덜 명시적이라는 생각이 들었습니다.
@RequestHeader(required = false)로 설정한 뒤 각 요청의 컨텍스트에 맞게 처리해야하는지,
아니면 인증 헤더를 전역에서 일괄 처리하는 것이 맞는 설계인지 고민입니다.

## ✅ Checklist
**🔗 통합 테스트**
- [x]  해당 ID 의 회원이 존재할 경우, 보유 포인트가 반환된다.
- [x]  해당 ID 의 회원이 존재하지 않을 경우, null 이 반환된다.

**🌐 E2E 테스트**
- [x]  포인트 조회에 성공할 경우, 보유 포인트를 응답으로 반환한다.
- [x]  `X-USER-ID` 헤더가 없을 경우, `400 Bad Request` 응답을 반환한다.

## 📎 References