### PR TITLE
[roucn9]Ranking System

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingCriteria.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingCriteria.java
@@ -1,0 +1,11 @@
+package com.loopers.application.ranking;
+
+import java.time.LocalDate;
+
+public record RankingCriteria() {
+    public record Query(
+            LocalDate targetDate,
+            int page,
+            int size
+    ) {}
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingFacade.java
@@ -1,0 +1,68 @@
+package com.loopers.application.ranking;
+
+import com.loopers.domain.product.ProductService;
+import com.loopers.domain.product.dto.ProductInfo;
+import com.loopers.domain.ranking.ProductRankingInfo;
+import com.loopers.domain.ranking.ProductRankingResult;
+import com.loopers.domain.ranking.RankingQueryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class RankingFacade {
+    
+    private final RankingQueryService rankingQueryService;
+    private final ProductService productService;
+    
+    public RankingResult.Query getRankings(RankingCriteria.Query criteria) {
+        Pageable pageable = PageRequest.of(criteria.page() - 1, criteria.size());
+        Page<ProductRankingInfo> rankingPage = rankingQueryService.getTopProducts(criteria.targetDate(), pageable);
+        
+        List<ProductRankingResult> enrichedRankings = enrichWithProductInfo(rankingPage.getContent());
+        
+        return new RankingResult.Query(
+                enrichedRankings,
+                criteria.page(),
+                rankingPage.getTotalPages(),
+                rankingPage.getTotalElements(),
+                rankingPage.hasNext(),
+                criteria.targetDate()
+        );
+    }
+    
+    private List<ProductRankingResult> enrichWithProductInfo(List<ProductRankingInfo> rankings) {
+        if (rankings.isEmpty()) {
+            return List.of();
+        }
+        
+        Set<Long> productIds = rankings.stream()
+                .map(ProductRankingInfo::productId)
+                .collect(Collectors.toSet());
+        
+        Map<Long, ProductInfo.Summary> productInfoMap = productService.getProductSummaries(productIds);
+        
+        return rankings.stream()
+                .map(ranking -> {
+                    ProductInfo.Summary productInfo = productInfoMap.get(ranking.productId());
+                    if (productInfo != null) {
+                        return ProductRankingResult.of(productInfo, ranking);
+                    } else {
+                        log.warn("Product info not found for ranking: productId={}", ranking.productId());
+                        return null;
+                    }
+                })
+                .filter(result -> result != null)
+                .toList();
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingResult.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingResult.java
@@ -1,0 +1,17 @@
+package com.loopers.application.ranking;
+
+import com.loopers.domain.ranking.ProductRankingResult;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record RankingResult() {
+    public record Query(
+            List<ProductRankingResult> rankings,
+            int currentPage,
+            int totalPages,
+            long totalElements,
+            boolean hasNext,
+            LocalDate targetDate
+    ) {}
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface ProductRepository {
     Product save(Product product);
@@ -18,6 +19,8 @@ public interface ProductRepository {
     List<Product> findByIds(List<Long> ids);
 
     Page<ProductWithLikeCountProjection> findProductsWithSort(ProductQuery.Summary command, Pageable pageable);
+    
+    List<ProductWithLikeCountProjection> findProductsWithLikeCountByIds(Set<Long> productIds);
 
     long countProductsWithFilter(String category, Long brandId);
     

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/dto/ProductInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/dto/ProductInfo.java
@@ -62,7 +62,8 @@ public class ProductInfo {
             String category,
             Long brandId,
             List<ImageInfo> images,
-            DetailInfo detail
+            DetailInfo detail,
+            RankingInfo ranking
     ) {
         public static Detail from(Product product) {
             return new Detail(
@@ -75,7 +76,24 @@ public class ProductInfo {
                     product.getImages().stream()
                             .map(ImageInfo::from)
                             .toList(),
-                    product.getDetail() != null ? DetailInfo.from(product.getDetail()) : null
+                    product.getDetail() != null ? DetailInfo.from(product.getDetail()) : null,
+                    null
+            );
+        }
+        
+        public static Detail from(Product product, RankingInfo ranking) {
+            return new Detail(
+                    product.getId(),
+                    product.getName(),
+                    product.getDescription(),
+                    product.getPrice(),
+                    product.getCategory(),
+                    product.getBrandId(),
+                    product.getImages().stream()
+                            .map(ImageInfo::from)
+                            .toList(),
+                    product.getDetail() != null ? DetailInfo.from(product.getDetail()) : null,
+                    ranking
             );
         }
     }
@@ -106,6 +124,18 @@ public class ProductInfo {
                     productDetail.getId(),
                     null,
                     productDetail.getDetailContent()
+            );
+        }
+    }
+
+    public record RankingInfo(
+            int rank,
+            double score
+    ) {
+        public static RankingInfo from(com.loopers.domain.ranking.ProductRankingInfo rankingInfo) {
+            return new RankingInfo(
+                    rankingInfo.rank(),
+                    rankingInfo.score()
             );
         }
     }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/ProductRankingInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/ProductRankingInfo.java
@@ -1,0 +1,11 @@
+package com.loopers.domain.ranking;
+
+public record ProductRankingInfo(
+        Long productId,
+        double score,
+        int rank
+) {
+    public static ProductRankingInfo of(Long productId, double score, int rank) {
+        return new ProductRankingInfo(productId, score, rank);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/ProductRankingResult.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/ProductRankingResult.java
@@ -1,0 +1,13 @@
+package com.loopers.domain.ranking;
+
+import com.loopers.domain.product.dto.ProductInfo;
+
+public record ProductRankingResult(
+        ProductInfo.Summary productInfo,
+        ProductRankingInfo rankingInfo,
+        int rank
+) {
+    public static ProductRankingResult of(ProductInfo.Summary productInfo, ProductRankingInfo rankingInfo) {
+        return new ProductRankingResult(productInfo, rankingInfo, rankingInfo.rank());
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingQueryService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingQueryService.java
@@ -1,0 +1,26 @@
+package com.loopers.domain.ranking;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RankingQueryService {
+    
+    private final RankingRepository rankingRepository;
+
+    public Page<ProductRankingInfo> getTopProducts(LocalDate date, Pageable pageable) {
+        return rankingRepository.getTopProducts(date, pageable);
+    }
+
+    public Optional<ProductRankingInfo> getProductRanking(Long productId, LocalDate date) {
+        return rankingRepository.getProductRanking(productId, date);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingRepository.java
@@ -1,0 +1,14 @@
+package com.loopers.domain.ranking;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+public interface RankingRepository {
+    
+    Page<ProductRankingInfo> getTopProducts(LocalDate date, Pageable pageable);
+    
+    Optional<ProductRankingInfo> getProductRanking(Long productId, LocalDate date);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepositoryCustom.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepositoryCustom.java
@@ -4,6 +4,9 @@ import com.loopers.domain.product.dto.ProductWithLikeCountProjection;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+import java.util.Set;
+
 public interface ProductJpaRepositoryCustom {
     
     Page<ProductWithLikeCountProjection> findProductsWithFilter(
@@ -19,4 +22,6 @@ public interface ProductJpaRepositoryCustom {
     );
     
     long countProductsWithFilter(String category, Long brandId);
+    
+    List<ProductWithLikeCountProjection> findProductsWithLikeCountByIds(Set<Long> productIds);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Component
 @RequiredArgsConstructor
@@ -46,6 +47,11 @@ public class ProductRepositoryImpl implements ProductRepository {
             return productJpaRepository.findProductsWithFilterByLikes(command.category(), command.brandId(), pageable);
         }
         return productJpaRepository.findProductsWithFilter(command.category(), command.brandId(), pageable);
+    }
+    
+    @Override
+    public List<ProductWithLikeCountProjection> findProductsWithLikeCountByIds(Set<Long> productIds) {
+        return productJpaRepository.findProductsWithLikeCountByIds(productIds);
     }
 
     @Override

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/RankingRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/RankingRepositoryImpl.java
@@ -1,0 +1,89 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.domain.ranking.ProductRankingInfo;
+import com.loopers.domain.ranking.RankingRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RankingRepositoryImpl implements RankingRepository {
+    
+    private final RedisTemplate<String, String> redisTemplate;
+    
+    private static final String RANKING_KEY_PREFIX = "ranking:all:";
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+    
+    @Override
+    public Page<ProductRankingInfo> getTopProducts(LocalDate date, Pageable pageable) {
+        String rankingKey = buildRankingKey(date);
+        
+        try {
+            long start = pageable.getOffset();
+            long end = start + pageable.getPageSize() - 1;
+            
+            Set<TypedTuple<String>> rankingsWithScore = redisTemplate.opsForZSet()
+                    .reverseRangeWithScores(rankingKey, start, end);
+            
+            Long totalCount = redisTemplate.opsForZSet().zCard(rankingKey);
+            
+            List<ProductRankingInfo> rankings = new ArrayList<>();
+            int rank = (int) start + 1;
+            
+            if (rankingsWithScore != null) {
+                for (TypedTuple<String> tuple : rankingsWithScore) {
+                    try {
+                        Long productId = Long.valueOf(tuple.getValue());
+                        Double score = tuple.getScore() != null ? tuple.getScore() : 0.0;
+                        rankings.add(ProductRankingInfo.of(productId, score, rank++));
+                    } catch (NumberFormatException e) {
+                        log.warn("Invalid product ID in ranking: {}", tuple.getValue());
+                    }
+                }
+            }
+            
+            return new PageImpl<>(rankings, pageable, totalCount != null ? totalCount : 0);
+            
+        } catch (Exception e) {
+            log.error("Failed to get top products: date={}, page={}", date, pageable, e);
+            return new PageImpl<>(Collections.emptyList(), pageable, 0);
+        }
+    }
+    
+    @Override
+    public Optional<ProductRankingInfo> getProductRanking(Long productId, LocalDate date) {
+        String rankingKey = buildRankingKey(date);
+        String productIdStr = productId.toString();
+        
+        try {
+            Double score = redisTemplate.opsForZSet().score(rankingKey, productIdStr);
+            if (score == null) {
+                return Optional.empty();
+            }
+            
+            Long rank = redisTemplate.opsForZSet().reverseRank(rankingKey, productIdStr);
+            int rankInt = rank != null ? rank.intValue() + 1 : -1;
+            
+            return Optional.of(ProductRankingInfo.of(productId, score, rankInt));
+            
+        } catch (Exception e) {
+            log.error("Failed to get product ranking: productId={}, date={}", productId, date, e);
+            return Optional.empty();
+        }
+    }
+    
+    private String buildRankingKey(LocalDate date) {
+        return RANKING_KEY_PREFIX + date.format(DATE_FORMATTER);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/GetRankings.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/GetRankings.java
@@ -1,0 +1,85 @@
+package com.loopers.interfaces.api.ranking;
+
+import com.loopers.application.ranking.RankingCriteria;
+import com.loopers.application.ranking.RankingResult;
+import com.loopers.domain.ranking.ProductRankingResult;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+public record GetRankings() {
+    public record V1() {
+        public record Request(
+                String date,
+                int page,
+                int size
+        ) {
+            public Request {
+                if (page <= 0) page = 1;
+                if (size <= 0) size = 20;
+                if (size > 100) size = 100;
+            }
+            
+            public RankingCriteria.Query toCriteria() {
+                LocalDate targetDate = (date != null && !date.isBlank()) 
+                    ? LocalDate.parse(date, DateTimeFormatter.ofPattern("yyyyMMdd"))
+                    : LocalDate.now();
+                return new RankingCriteria.Query(targetDate, page, size);
+            }
+        }
+
+        public record Response(
+                List<RankingItem> rankings,
+                int currentPage,
+                int totalPages,
+                long totalElements,
+                boolean hasNext,
+                String targetDate
+        ) {
+            public static Response from(RankingResult.Query result) {
+                List<RankingItem> rankingItems = result.rankings().stream()
+                        .map(RankingItem::from)
+                        .toList();
+                
+                String targetDateStr = result.targetDate().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+                
+                return new Response(
+                        rankingItems,
+                        result.currentPage(),
+                        result.totalPages(),
+                        result.totalElements(),
+                        result.hasNext(),
+                        targetDateStr
+                );
+            }
+            
+            public record RankingItem(
+                    int rank,
+                    Long productId,
+                    String productName,
+                    BigDecimal price,
+                    String description,
+                    String category,
+                    Long brandId,
+                    Long likeCount,
+                    double score
+            ) {
+                public static RankingItem from(ProductRankingResult result) {
+                    return new RankingItem(
+                            result.rank(),
+                            result.productInfo().id(),
+                            result.productInfo().name(),
+                            result.productInfo().price(),
+                            result.productInfo().description(),
+                            result.productInfo().category(),
+                            result.productInfo().brandId(),
+                            result.productInfo().likeCount(),
+                            result.rankingInfo().score()
+                    );
+                }
+            }
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1ApiController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1ApiController.java
@@ -1,0 +1,35 @@
+package com.loopers.interfaces.api.ranking;
+
+import com.loopers.application.ranking.RankingCriteria;
+import com.loopers.application.ranking.RankingFacade;
+import com.loopers.application.ranking.RankingResult;
+import com.loopers.interfaces.api.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/rankings")
+public class RankingV1ApiController implements RankingV1ApiSpec {
+
+    private final RankingFacade rankingFacade;
+
+    @Override
+    @GetMapping
+    public ApiResponse<GetRankings.V1.Response> getRankings(
+            @ModelAttribute GetRankings.V1.Request request
+    ) {
+        log.debug("Get rankings request: {}", request);
+        
+        RankingCriteria.Query criteria = request.toCriteria();
+        RankingResult.Query result = rankingFacade.getRankings(criteria);
+        GetRankings.V1.Response response = GetRankings.V1.Response.from(result);
+        
+        log.debug("Get rankings response: {} items, page {}/{}", 
+                 response.rankings().size(), response.currentPage(), response.totalPages());
+        
+        return ApiResponse.success(response);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1ApiSpec.java
@@ -1,0 +1,8 @@
+package com.loopers.interfaces.api.ranking;
+
+import com.loopers.interfaces.api.ApiResponse;
+import org.springframework.web.bind.annotation.ModelAttribute;
+
+public interface RankingV1ApiSpec {
+    ApiResponse<GetRankings.V1.Response> getRankings(@ModelAttribute GetRankings.V1.Request request);
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingRepository.java
@@ -1,0 +1,8 @@
+package com.loopers.domain.ranking;
+
+import java.time.LocalDate;
+import java.util.Map;
+
+public interface RankingRepository {
+    void updateProductScores(Map<Long, Double> productScores, LocalDate date);
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingScoreCalculator.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingScoreCalculator.java
@@ -1,0 +1,31 @@
+package com.loopers.domain.ranking;
+
+import com.loopers.events.like.LikeAddedEvent;
+import com.loopers.events.like.LikeRemovedEvent;
+import com.loopers.events.order.OrderCompletedEvent;
+import com.loopers.events.product.ProductViewedEvent;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RankingScoreCalculator {
+    
+    private static final double VIEW_WEIGHT = 0.1;
+    private static final double LIKE_WEIGHT = 0.2;
+    private static final double ORDER_WEIGHT = 0.6;
+    
+    public double calculateViewScore(ProductViewedEvent event) {
+        return VIEW_WEIGHT;
+    }
+
+    public double calculateLikeAddedScore(LikeAddedEvent event) {
+        return LIKE_WEIGHT;
+    }
+
+    public double calculateLikeRemovedScore(LikeRemovedEvent event) {
+        return -LIKE_WEIGHT;
+    }
+
+    public double calculateOrderItemScore(OrderCompletedEvent.OrderItemInfo item) {
+        return item.getPrice().doubleValue() * item.getQuantity() * ORDER_WEIGHT;
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingService.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingService.java
@@ -1,0 +1,20 @@
+package com.loopers.domain.ranking;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RankingService {
+    
+    private final RankingRepository rankingRepository;
+    
+    public void updateProductScores(Map<Long, Double> productScores, LocalDate date) {
+        rankingRepository.updateProductScores(productScores, date);
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/ranking/RankingRepositoryImpl.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/ranking/RankingRepositoryImpl.java
@@ -1,0 +1,56 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.domain.ranking.RankingRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RankingRepositoryImpl implements RankingRepository {
+    
+    private final RedisTemplate<String, String> rankingRedisTemplate;
+    
+    private static final String RANKING_KEY_PREFIX = "ranking:all:";
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+    private static final long TTL_HOURS = 48;
+
+    @Override
+    public void updateProductScores(Map<Long, Double> productScores, LocalDate date) {
+        if (productScores.isEmpty()) {
+            return;
+        }
+        
+        String rankingKey = buildRankingKey(date);
+        
+        try {
+            // Redis Pipeline
+            rankingRedisTemplate.executePipelined((org.springframework.data.redis.core.RedisCallback<Object>) connection -> {
+                for (Map.Entry<Long, Double> entry : productScores.entrySet()) {
+                    String productIdStr = entry.getKey().toString();
+                    double score = entry.getValue();
+                    rankingRedisTemplate.opsForZSet().incrementScore(rankingKey, productIdStr, score);
+                }
+                rankingRedisTemplate.expire(rankingKey, TTL_HOURS, TimeUnit.HOURS);
+                return null;
+            });
+            
+            log.debug("Updated {} product scores for date: {}", productScores.size(), date);
+        } catch (Exception e) {
+            log.error("Failed to update product scores batch: date={}, count={}", 
+                     date, productScores.size(), e);
+            throw new RuntimeException("Failed to update ranking scores batch", e);
+        }
+    }
+
+    private String buildRankingKey(LocalDate date) {
+        return RANKING_KEY_PREFIX + date.format(DATE_FORMATTER);
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/ConsumerGroupConstants.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/ConsumerGroupConstants.java
@@ -5,6 +5,7 @@ public class ConsumerGroupConstants {
     public static final String AUDIT_LOG = "audit-log";
     public static final String METRICS_AGGREGATOR = "metrics-aggregator"; 
     public static final String PRODUCT_INFO = "product-info";
+    public static final String RANKING = "ranking-aggregator";
     
     private ConsumerGroupConstants() {}
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/RankingConsumer.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/RankingConsumer.java
@@ -1,0 +1,119 @@
+package com.loopers.interfaces.consumer;
+
+import com.loopers.confg.kafka.KafkaConfig;
+import com.loopers.domain.common.messaging.IdempotencyService;
+import com.loopers.domain.ranking.RankingScoreCalculator;
+import com.loopers.domain.ranking.RankingService;
+import com.loopers.events.common.DomainEvent;
+import com.loopers.events.like.LikeAddedEvent;
+import com.loopers.events.like.LikeRemovedEvent;
+import com.loopers.events.order.OrderCompletedEvent;
+import com.loopers.events.product.ProductViewedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RankingConsumer {
+    
+    private final RankingService rankingService;
+    private final RankingScoreCalculator scoreCalculator;
+    private final IdempotencyService idempotencyService;
+    
+    @KafkaListener(
+        topics = {"product-view-events", "like-events", "order-events"},
+        containerFactory = KafkaConfig.BATCH_LISTENER,
+        groupId = ConsumerGroupConstants.RANKING
+    )
+    @Transactional
+    public void handleEvents(List<ConsumerRecord<String, DomainEvent>> records, Acknowledgment ack) {
+        log.debug("RankingConsumer received {} events", records.size());
+        
+        Map<LocalDate, Map<Long, Double>> scoresByDate = new HashMap<>();
+        
+        for (ConsumerRecord<String, DomainEvent> record : records) {
+            DomainEvent event = record.value();
+            
+            if (idempotencyService.isProcessed(event.getEventId(), ConsumerGroupConstants.RANKING)) {
+                log.debug("Event already processed by RankingConsumer: eventId={}", event.getEventId());
+                continue;
+            }
+            
+            try {
+                processEvent(event, scoresByDate);
+                idempotencyService.markAsProcessed(event.getEventId(), ConsumerGroupConstants.RANKING);
+                
+            } catch (Exception e) {
+                log.error("Failed to process event in RankingConsumer: eventId={}", event.getEventId(), e);
+                throw e;
+            }
+        }
+        
+        updateScoresBatch(scoresByDate);
+        
+        ack.acknowledge();
+        log.debug("RankingConsumer processed {} events successfully", records.size());
+    }
+    
+    private void processEvent(DomainEvent event, Map<LocalDate, Map<Long, Double>> scoresByDate) {
+        LocalDate eventDate = event.getOccurredOn().toLocalDate();
+        
+        if (event instanceof ProductViewedEvent viewEvent) {
+            double score = scoreCalculator.calculateViewScore(viewEvent);
+            addScore(scoresByDate, eventDate, viewEvent.getProductId(), score);
+            
+        } else if (event instanceof LikeAddedEvent likeAddedEvent) {
+            double score = scoreCalculator.calculateLikeAddedScore(likeAddedEvent);
+            addScore(scoresByDate, eventDate, likeAddedEvent.getProductId(), score);
+            
+        } else if (event instanceof LikeRemovedEvent likeRemovedEvent) {
+            double score = scoreCalculator.calculateLikeRemovedScore(likeRemovedEvent);
+            addScore(scoresByDate, eventDate, likeRemovedEvent.getProductId(), score);
+            
+        } else if (event instanceof OrderCompletedEvent orderEvent) {
+            processOrderEvent(orderEvent, scoresByDate, eventDate);
+            
+        } else {
+            log.debug("Unsupported event type for ranking: {}", event.getEventType());
+        }
+    }
+    
+    private void processOrderEvent(OrderCompletedEvent orderEvent, 
+                                   Map<LocalDate, Map<Long, Double>> scoresByDate, 
+                                   LocalDate eventDate) {
+        for (OrderCompletedEvent.OrderItemInfo item : orderEvent.getOrderItems()) {
+            double itemScore = scoreCalculator.calculateOrderItemScore(item);
+            addScore(scoresByDate, eventDate, item.getProductId(), itemScore);
+        }
+    }
+    
+    private void addScore(Map<LocalDate, Map<Long, Double>> scoresByDate, 
+                         LocalDate date, Long productId, double score) {
+        scoresByDate.computeIfAbsent(date, k -> new HashMap<>())
+                   .merge(productId, score, Double::sum);
+    }
+    
+    private void updateScoresBatch(Map<LocalDate, Map<Long, Double>> scoresByDate) {
+        for (Map.Entry<LocalDate, Map<Long, Double>> dateEntry : scoresByDate.entrySet()) {
+            LocalDate date = dateEntry.getKey();
+            Map<Long, Double> productScores = dateEntry.getValue();
+            
+            if (!productScores.isEmpty()) {
+                rankingService.updateProductScores(productScores, date);
+                log.debug("Updated ranking scores for date: {}, products: {}", 
+                         date, productScores.size());
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 📌 Summary
랭킹 시스템 구현 

## 💬 Review Points
### 1. 이전 랭킹을 반영하는 방법과 콜드 스타트 스케줄러
스케줄은 시간상 구현을 아직 못했습니다.......
이전 날짜의 랭킹을 반영하는 방법이 2가지가 있다고 생각했는데요...
#### 스케줄러로 콜드 스타트
- 자정 전 백그라운드에서 미리 연산
- 미리 데이터를 캐시하므로 캐시히트 방지

#### 캐시를 조회하는 시점에 실시간으로 두 일자의 데이터를 조합
- 처음엔 이런 식으로 조합해서 조회할 생각이었습니다.(각 일자의 데이터의 가중치를 다르게 부여)
- 별도의 스케줄러 구현이 필요없고, 매번 연산을 한다는 단점이 존재
하지만 실시간성 관점에서는 어차피 자정이 지난 직후에는 오늘의 데이터가 거의 없기 때문에 사실상 전날의 랭킹 데이터만 볼 수밖에 없는 건 스케줄러도 마찬가지고, 두 구현방식이 크게 차이가 없을 거라는 생각이 들었습니다.

물론 당연히 스케줄러가 더 안정적인 구현이지만 두번째 방식도 아예 불가능한 건 아니라는 생각이 들어서요...
실제로 두번째 방법과 유사한 방법을 사용하는 경우가 있을까요?

### 2. 폴백 전략
만약 랭킹 데이터가 없다면 폴백용 랭킹 데이터도 캐싱이나 그냥 하드코딩, 또는 설정파일로 값을 관리하도록 구현할 수 있을 것 같은데,
Cloud Config...? 같은 걸로도 관리할 수 있다고 하는 것 같아서요! 실제로 폴백용 데이터를 이런 식으로 관리하기도 하나요?

### 3. 개인화 랭킹
만약 사용자 별 랭킹 데이터를 조회할 수 있도록 한다면, 캐시된 랭킹에 별도의 가중치를 더해 구현하는 방식일까요? 
아니면 아예 별도로 랭킹하는 걸까요? 만약 사용자 별 가중치를 더해서 랭킹하는 형식이라면 이 경우엔 DB나 Elasticsearch에서 사용자별 데이터를 조회해서 더하는 방식일 것 같은데, 실제로 어떤 방식으로 많이 구현될까요..?

### 4. 알렌님만의 체력관리비결
요즘 상당히 바빠보이십니다..ㅋㅋㅋ ㅠㅠ 아무래도 야근이 잦아 체력적으로 힘든 날도 있을 것 같은데,  멘토님은 어떤 식으로 컨디션 관리를 하시나요 ㅠㅠ? 체력과 정신력 관리 비법이 궁금합니다... 어떻게 열정을 계속 유지하시나요? 커리어 고민을 해보신 적도 있나요? 

## ✅ Checklist
### 📈 Ranking Consumer
- [ ]  랭킹 ZSET 의 TTL, 키 전략을 적절하게 구성하였다
- [ ]  날짜별로 적재할 키를 계산하는 기능을 만들었다
- [ ]  이벤트가 발생한 후, ZSET 에 점수가 적절하게 반영된다

### ⚾ Ranking API
- [ ]  랭킹 Page 조회 시 정상적으로 랭킹 정보가 반환된다
- [ ]  랭킹 Page 조회 시 단순히 상품 ID 가 아닌 상품정보가 Aggregation 되어 제공된다
- [ ]  상품 상세 조회 시 해당 상품의 순위가 함께 반환된다 (순위에 없다면 null)